### PR TITLE
Update node support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
   - linux
   - osx
 node_js:
-  - lts/*
-  - node
+  - 8
+  - 11
 script: yarn test+coverage
 after_success:
   - yarn coveralls

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=4.0.0 <12"
   },
   "description": "A gulp plugin that provides a persisted file cache",
   "keywords": [


### PR DESCRIPTION
Since this plugin currently works with gulp v3, which doesn't support node v12